### PR TITLE
Support spread_level for placement-group module

### DIFF
--- a/modules/placement-group/README.md
+++ b/modules/placement-group/README.md
@@ -12,13 +12,13 @@ This module creates following resources.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.20 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.22 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.14.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.23.0 |
 
 ## Modules
 
@@ -42,6 +42,7 @@ No modules.
 | <a name="input_resource_group_description"></a> [resource\_group\_description](#input\_resource\_group\_description) | (Optional) The description of Resource Group. | `string` | `"Managed by Terraform."` | no |
 | <a name="input_resource_group_enabled"></a> [resource\_group\_enabled](#input\_resource\_group\_enabled) | (Optional) Whether to create Resource Group to find and group AWS resources which are created by this module. | `bool` | `true` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | (Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. | `string` | `""` | no |
+| <a name="input_spread_level"></a> [spread\_level](#input\_spread\_level) | (Optional) The spread level to determine how the placement group spread instances. Can only be specified when the `strategy` is set to `SPREAD`. Valid values are `HOST` and `RACK`. `HOST` can only be used for Outpost placement groups. | `string` | `"RACK"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A map of tags to add to all resources. | `map(string)` | `{}` | no |
 
 ## Outputs
@@ -52,5 +53,6 @@ No modules.
 | <a name="output_id"></a> [id](#output\_id) | The ID of the placement group. |
 | <a name="output_name"></a> [name](#output\_name) | The name of the placement group. |
 | <a name="output_partition_size"></a> [partition\_size](#output\_partition\_size) | The number of partitions in the placement group. Only configured when the `strategy` is `PARTITION`. |
+| <a name="output_spread_level"></a> [spread\_level](#output\_spread\_level) | The spread level to determine how the placement group spread instance. Only configured when the `strategy` is `SPREAD`. |
 | <a name="output_strategy"></a> [strategy](#output\_strategy) | The placement strategy. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/placement-group/main.tf
+++ b/modules/placement-group/main.tf
@@ -34,6 +34,10 @@ resource "aws_placement_group" "this" {
     ? var.partition_size
     : null
   )
+  spread_level = (var.strategy == "SPREAD"
+    ? lower(var.spread_level)
+    : null
+  )
 
   tags = merge(
     {

--- a/modules/placement-group/outputs.tf
+++ b/modules/placement-group/outputs.tf
@@ -22,3 +22,8 @@ output "partition_size" {
   description = "The number of partitions in the placement group. Only configured when the `strategy` is `PARTITION`."
   value       = aws_placement_group.this.partition_count
 }
+
+output "spread_level" {
+  description = "The spread level to determine how the placement group spread instance. Only configured when the `strategy` is `SPREAD`."
+  value       = upper(aws_placement_group.this.spread_level)
+}

--- a/modules/placement-group/variables.tf
+++ b/modules/placement-group/variables.tf
@@ -26,6 +26,18 @@ variable "partition_size" {
   nullable    = false
 }
 
+variable "spread_level" {
+  description = "(Optional) The spread level to determine how the placement group spread instances. Can only be specified when the `strategy` is set to `SPREAD`. Valid values are `HOST` and `RACK`. `HOST` can only be used for Outpost placement groups."
+  type        = string
+  default     = "RACK"
+  nullable    = false
+
+  validation {
+    condition     = contains(["HOST", "RACK"], var.spread_level)
+    error_message = "Valid values are `HOST`, or `RACK`."
+  }
+}
+
 variable "tags" {
   description = "(Optional) A map of tags to add to all resources."
   type        = map(string)

--- a/modules/placement-group/versions.tf
+++ b/modules/placement-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.20"
+      version = ">= 4.22"
     }
   }
 }


### PR DESCRIPTION
### Background

- https://github.com/hashicorp/terraform-provider-aws/releases/tag/v4.22.0
  - Add `spread_level` parameter for `placement-group` resource.