### PR TITLE
Fix output error in placement-group module

### DIFF
--- a/modules/placement-group/outputs.tf
+++ b/modules/placement-group/outputs.tf
@@ -25,5 +25,5 @@ output "partition_size" {
 
 output "spread_level" {
   description = "The spread level to determine how the placement group spread instance. Only configured when the `strategy` is `SPREAD`."
-  value       = upper(aws_placement_group.this.spread_level)
+  value       = try(upper(aws_placement_group.this.spread_level), null)
 }


### PR DESCRIPTION
### Background

- output error when `strategy` is not `SPREAD`.

```bash
│ Error: Invalid function argument
│
│   on .terraform/modules/placement_group/modules/placement-group/outputs.tf line 28, in output "spread_level":
│   28:   value       = upper(aws_placement_group.this.spread_level)
│     ├────────────────
│     │ aws_placement_group.this.spread_level is null
│
│ Invalid value for "str" parameter: argument must not be null.
```