### PR TITLE
Add ssh-key module

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -5,3 +5,5 @@
 - modules/instance-group/**/*
 ":floppy_disk: placement-group":
 - modules/placement-group/**/*
+":floppy_disk: ssh-key":
+- modules/ssh-key/**/*

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -49,3 +49,6 @@
 - color: "fbca04"
   description: "This issue or pull request is related to placement-group module."
   name: ":floppy_disk: placement-group"
+- color: "fbca04"
+  description: "This issue or pull request is related to ssh-key module."
+  name: ":floppy_disk: ssh-key"

--- a/modules/placement-group/variables.tf
+++ b/modules/placement-group/variables.tf
@@ -42,12 +42,14 @@ variable "tags" {
   description = "(Optional) A map of tags to add to all resources."
   type        = map(string)
   default     = {}
+  nullable    = false
 }
 
 variable "module_tags_enabled" {
   description = "(Optional) Whether to create AWS Resource Tags for the module informations."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 
@@ -59,16 +61,19 @@ variable "resource_group_enabled" {
   description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "resource_group_name" {
   description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "resource_group_description" {
   description = "(Optional) The description of Resource Group."
   type        = string
   default     = "Managed by Terraform."
+  nullable    = false
 }

--- a/modules/ssh-key/README.md
+++ b/modules/ssh-key/README.md
@@ -1,0 +1,53 @@
+# ssh-key
+
+This module creates following resources.
+
+- `aws_key_pair`
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.22 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.24.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_key_pair.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/key_pair) | resource |
+| [aws_resourcegroups_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/resourcegroups_group) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_name"></a> [name](#input\_name) | (Required) The name of the SSH key pair. | `string` | n/a | yes |
+| <a name="input_public_key"></a> [public\_key](#input\_public\_key) | (Optional) The public key material. | `string` | n/a | yes |
+| <a name="input_module_tags_enabled"></a> [module\_tags\_enabled](#input\_module\_tags\_enabled) | (Optional) Whether to create AWS Resource Tags for the module informations. | `bool` | `true` | no |
+| <a name="input_resource_group_description"></a> [resource\_group\_description](#input\_resource\_group\_description) | (Optional) The description of Resource Group. | `string` | `"Managed by Terraform."` | no |
+| <a name="input_resource_group_enabled"></a> [resource\_group\_enabled](#input\_resource\_group\_enabled) | (Optional) Whether to create Resource Group to find and group AWS resources which are created by this module. | `bool` | `true` | no |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | (Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. | `string` | `""` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A map of tags to add to all resources. | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_arn"></a> [arn](#output\_arn) | The Amazon Resource Name (ARN) of the SSH key pair. |
+| <a name="output_fingerprint"></a> [fingerprint](#output\_fingerprint) | The MD5 public key fingerprint as specified in section 4 of RFC 4716. |
+| <a name="output_id"></a> [id](#output\_id) | The ID of the SSH key pair. |
+| <a name="output_name"></a> [name](#output\_name) | The name of the SSH key pair. |
+| <a name="output_type"></a> [type](#output\_type) | The type of the SSH key pair. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/ssh-key/main.tf
+++ b/modules/ssh-key/main.tf
@@ -1,0 +1,41 @@
+locals {
+  metadata = {
+    package = "terraform-aws-ec2"
+    version = trimspace(file("${path.module}/../../VERSION"))
+    module  = basename(path.module)
+    name    = var.name
+  }
+  module_tags = var.module_tags_enabled ? {
+    "module.terraform.io/package"   = local.metadata.package
+    "module.terraform.io/version"   = local.metadata.version
+    "module.terraform.io/name"      = local.metadata.module
+    "module.terraform.io/full-name" = "${local.metadata.package}/${local.metadata.module}"
+    "module.terraform.io/instance"  = local.metadata.name
+  } : {}
+}
+
+locals {
+  strategy = {
+    "CLUSTER"   = "cluster"
+    "PARTITION" = "partition"
+    "SPREAD"    = "spread"
+  }
+}
+
+
+###################################################
+# SSH Key Pair for EC2 Instances
+###################################################
+
+resource "aws_key_pair" "this" {
+  key_name   = var.name
+  public_key = var.public_key
+
+  tags = merge(
+    {
+      "Name" = local.metadata.name
+    },
+    local.module_tags,
+    var.tags,
+  )
+}

--- a/modules/ssh-key/outputs.tf
+++ b/modules/ssh-key/outputs.tf
@@ -1,0 +1,24 @@
+output "id" {
+  description = "The ID of the SSH key pair."
+  value       = aws_key_pair.this.key_pair_id
+}
+
+output "arn" {
+  description = "The Amazon Resource Name (ARN) of the SSH key pair."
+  value       = aws_key_pair.this.arn
+}
+
+output "name" {
+  description = "The name of the SSH key pair."
+  value       = aws_key_pair.this.key_name
+}
+
+output "fingerprint" {
+  description = "The MD5 public key fingerprint as specified in section 4 of RFC 4716."
+  value       = aws_key_pair.this.fingerprint
+}
+
+output "type" {
+  description = "The type of the SSH key pair."
+  value       = aws_key_pair.this.key_type
+}

--- a/modules/ssh-key/resource-group.tf
+++ b/modules/ssh-key/resource-group.tf
@@ -1,0 +1,44 @@
+locals {
+  resource_group_name = (var.resource_group_name != ""
+    ? var.resource_group_name
+    : join(".", [
+      local.metadata.package,
+      local.metadata.module,
+      replace(local.metadata.name, "/[^a-zA-Z0-9_\\.-]/", "-"),
+    ])
+  )
+  resource_group_filters = [
+    for key, value in local.module_tags : {
+      "Key"    = key
+      "Values" = [value]
+    }
+  ]
+  resource_group_query = <<-JSON
+  {
+    "ResourceTypeFilters": [
+      "AWS::AllSupported"
+    ],
+    "TagFilters": ${jsonencode(local.resource_group_filters)}
+  }
+  JSON
+}
+
+resource "aws_resourcegroups_group" "this" {
+  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+
+  name        = local.resource_group_name
+  description = var.resource_group_description
+
+  resource_query {
+    type  = "TAG_FILTERS_1_0"
+    query = local.resource_group_query
+  }
+
+  tags = merge(
+    {
+      "Name" = local.resource_group_name
+    },
+    local.module_tags,
+    var.tags,
+  )
+}

--- a/modules/ssh-key/variables.tf
+++ b/modules/ssh-key/variables.tf
@@ -1,0 +1,51 @@
+variable "name" {
+  description = "(Required) The name of the SSH key pair."
+  type        = string
+  nullable    = false
+}
+
+variable "public_key" {
+  description = "(Optional) The public key material."
+  type        = string
+  nullable    = false
+}
+
+variable "tags" {
+  description = "(Optional) A map of tags to add to all resources."
+  type        = map(string)
+  default     = {}
+  nullable    = false
+}
+
+variable "module_tags_enabled" {
+  description = "(Optional) Whether to create AWS Resource Tags for the module informations."
+  type        = bool
+  default     = true
+  nullable    = false
+}
+
+
+###################################################
+# Resource Group
+###################################################
+
+variable "resource_group_enabled" {
+  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
+  type        = bool
+  default     = true
+  nullable    = false
+}
+
+variable "resource_group_name" {
+  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
+  type        = string
+  default     = ""
+  nullable    = false
+}
+
+variable "resource_group_description" {
+  description = "(Optional) The description of Resource Group."
+  type        = string
+  default     = "Managed by Terraform."
+  nullable    = false
+}

--- a/modules/ssh-key/versions.tf
+++ b/modules/ssh-key/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.2"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.22"
+    }
+  }
+}


### PR DESCRIPTION
### Background

- Add `ssh-key` module to support EC2 SSH Key Pairs.