### PR TITLE
fix(instance): drop default VPC support so subnet can be unknown at plan time

### DIFF
--- a/modules/instance/security-group.tf
+++ b/modules/instance/security-group.tf
@@ -1,20 +1,18 @@
-data "aws_vpc" "default" {
-  count = var.subnet == null ? 1 : 0
-
-  default = true
-}
-
 data "aws_subnet" "this" {
-  count = var.subnet != null ? 1 : 0
+  count = var.default_security_group.enabled ? 1 : 0
 
   id = var.subnet
+
+  lifecycle {
+    precondition {
+      condition     = var.subnet != null
+      error_message = "`subnet` is required when `default_security_group.enabled` is `true`, because the security group is created in the subnet's VPC. The default VPC is not supported."
+    }
+  }
 }
 
 locals {
-  vpc_id = (var.subnet != null
-    ? data.aws_subnet.this[0].vpc_id
-    : data.aws_vpc.default[0].id
-  )
+  vpc_id = var.default_security_group.enabled ? data.aws_subnet.this[0].vpc_id : null
 
   security_groups = (var.default_security_group.enabled
     ? concat(module.security_group[*].id, var.security_groups)


### PR DESCRIPTION
## Problem

The `instance` module's security-group data sources gate `count` on the value of `var.subnet`:

```hcl
data "aws_vpc" "default" {
  count   = var.subnet == null ? 1 : 0
  default = true
}
data "aws_subnet" "this" {
  count = var.subnet != null ? 1 : 0
  id    = var.subnet
}
```

When `subnet` is an **unknown value at plan time** — e.g. a subnet id created by another resource in the same `apply` (`module.my_subnets.ids[0]`) — Terraform cannot evaluate the `count`:

```
Error: Invalid count argument
  The "count" value depends on resource attributes that cannot be determined
  until apply, so Terraform cannot predict how many instances will be created.
```

This forces a two-phase `apply` (`-target` the subnets first), which breaks single-apply workflows where the network and the instance are created together.

## Fix

Drop the implicit **default-VPC fallback** (`data.aws_vpc.default`) and gate the subnet lookup on `default_security_group.enabled` — a **known boolean** — instead of on the (possibly unknown) `subnet` value:

```hcl
data "aws_subnet" "this" {
  count = var.default_security_group.enabled ? 1 : 0
  id    = var.subnet

  lifecycle {
    precondition {
      condition     = var.subnet != null
      error_message = "`subnet` is required when `default_security_group.enabled` is `true` ... The default VPC is not supported."
    }
  }
}

locals {
  vpc_id = var.default_security_group.enabled ? data.aws_subnet.this[0].vpc_id : null
}
```

`data` sources tolerate unknown arguments (the read defers to apply); only `count`/`for_each` cannot depend on unknowns. Moving the gate to a known boolean resolves the plan-time error.

## Verification

Tested against a config where `subnet` is unknown at plan time (`subnet = "subnet-${random_id.x.hex}"`):

- **Before:** `Error: Invalid count argument`
- **After:** the `count` evaluates cleanly; planning proceeds.

## Breaking change

The default VPC is no longer used as a fallback. When `default_security_group.enabled = true` (the default), `subnet` is now **required**; omitting it produces a clear precondition error instead of silently using the default VPC. Callers who relied on the default-VPC behavior must pass an explicit `subnet`.